### PR TITLE
fix mode for dkim directory

### DIFF
--- a/roles/rspamd/tasks/main.yml
+++ b/roles/rspamd/tasks/main.yml
@@ -83,7 +83,7 @@
     recurse: yes
     owner: _rspamd
     group: _rspamd
-    mode: "0440"
+    mode: u=rX,g=rX,o= # capital 'X': execute flag only for directories
   tags: rspamd
 
 - name: Copy arc.conf


### PR DESCRIPTION
Hi,
this is very nice work :-)
In my case (Ubuntu 22.04) rspamd couldn't couldn't sign outgoing mail with this error message:
2023-11-18 21:19:07 #122286(rspamd_proxy) <5da4dd>; proxy; dkim_module_load_key_format: cannot load dkim key /var/lib/rspamd/dkim/dkim_key.key: **cannot stat key file:** '/var/lib/rspamd/dkim/dkim_key.key' Permission denied

The **cannot stat** error is because the directory /var/lib/rspamd/dkim didn't have the executable flag set. With this commit, everything works as expected.

Kind regards,
Hanno

