### PR TITLE
align configured dkim_key selector with generated key file

### DIFF
--- a/roles/rspamd/files/arc.conf
+++ b/roles/rspamd/files/arc.conf
@@ -1,5 +1,5 @@
 path = "/var/lib/rspamd/dkim/$selector.key"
-selector = "2019"
+selector = "dkim_key"
 
 ### Enable DKIM signing for alias sender addresses
 allow_username_mismatch = true

--- a/roles/rspamd/files/dkim_signing.conf
+++ b/roles/rspamd/files/dkim_signing.conf
@@ -1,5 +1,5 @@
 path = "/var/lib/rspamd/dkim/$selector.key"
-selector = "2019"
+selector = "dkim_key"
 
 ### Enable DKIM signing for alias sender addresses
 allow_username_mismatch = true


### PR DESCRIPTION
first: thanks a lot for your great work, I appreciate it!
in the rspamd configs the dkim_key selector is hardcoded to 2019, while it is being created as dkim_key. This PR fixes the issue